### PR TITLE
Loading nif in escript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ c_src/*.o
 ebin/
 _build/
 .rebar
+*.swp

--- a/src/encurses.erl
+++ b/src/encurses.erl
@@ -90,11 +90,7 @@
 %% =============================================================================
 
 load_nif() ->
-    Dir = case code:priv_dir(encurses) of
-        {error, bad_name} ->
-            filename:dirname(code:which(?MODULE)) ++ "/../priv";
-        OtherDir -> OtherDir
-    end,
+    Dir = paths:nif_dir(),
     erlang:load_nif(Dir ++ "/encurses", 0).
 
 %% =============================================================================

--- a/src/paths.erl
+++ b/src/paths.erl
@@ -1,0 +1,17 @@
+-module(paths).
+-export([nif_dir/0, nif_dir/2]).
+
+nif_dir() -> 
+    Cpd = code:priv_dir(encurses),
+    MoCpd = filename:dirname(code:which(?MODULE)) ++ "/../priv",
+    nif_dir(Cpd, MoCpd).
+
+
+nif_dir({error, _}, ModulePrivDir) -> handle_escript_format(ModulePrivDir);
+nif_dir(Dir, _) -> handle_escript_format(Dir).
+
+handle_escript_format(Dir) -> 
+    Handled = re:replace(Dir, 
+               "(_build/[^/]+)/bin/([^/]+)/encurses/priv",
+               "\\1/lib/encurses/priv"),
+    binary_to_list(iolist_to_binary(Handled)).

--- a/test/nif_path_test.erl
+++ b/test/nif_path_test.erl
@@ -1,0 +1,18 @@
+-module(nif_path_test).
+-include_lib("eunit/include/eunit.hrl").
+
+'use the module priv directory when code priv isnt known_test'() ->
+    NifDir = paths:nif_dir({error, bad_name}, "module dir"),
+    ?assertEqual("module dir", NifDir).
+
+'use the code priv directory_test'() -> 
+    NifDir = paths:nif_dir("./priv", "module dir"),
+    ?assertEqual("./priv", NifDir).
+
+'find the lib dir when in a bin escript directory_test'() ->
+    NifDir = paths:nif_dir("/dir/_build/default/bin/app/encurses/priv", "module dir"),
+    ?assertEqual("/dir/_build/default/lib/encurses/priv", NifDir).
+
+'find the lib dir when in a bin escript directory when code priv was not found_test'() ->
+    NifDir = paths:nif_dir({error, bad_name}, "/dir/_build/default/bin/app/encurses/priv"),
+    ?assertEqual("/dir/_build/default/lib/encurses/priv", NifDir).


### PR DESCRIPTION
Hi, 

First of all thank you for writing this, I am very glad to have found it. I am writing an escript and loading the nif failed, it looked in the wrong repository.

I fixed it as I could, I am new to erlang so I don't master the api and this looks like a hack.

What do you think ?